### PR TITLE
Feature/ble read data

### DIFF
--- a/lib/connection/ble/bluetooth_backend.dart
+++ b/lib/connection/ble/bluetooth_backend.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:flutter_blue/flutter_blue.dart';
 import 'dart:developer' as developer;
 
@@ -42,10 +43,12 @@ class BluetoothBackend {
       List<BluetoothDevice> devicesSnapshot) async {
     List<BluetoothCharacteristic> characteristics = <BluetoothCharacteristic>[];
     for (var device in devicesSnapshot) {
-      BluetoothService service = await getMeasurementService(device);
-      BluetoothCharacteristic measurementCharacteristic =
-          getMeasurementCharacteristic(service);
-      characteristics.add(measurementCharacteristic);
+      BluetoothService? service = await getMeasurementService(device);
+      if (service != null) {
+        BluetoothCharacteristic measurementCharacteristic =
+        getMeasurementCharacteristic(service);
+        characteristics.add(measurementCharacteristic);
+      }
     }
     developer.log("Measurement characteristics: $characteristics", name: TAG);
     return characteristics;
@@ -63,13 +66,13 @@ class BluetoothBackend {
   }
 
   /// Retrieves the measurement service from the specified device.
-  static Future<BluetoothService> getMeasurementService(
+  static Future<BluetoothService?> getMeasurementService(
       BluetoothDevice bluetoothDevice) async {
     List<BluetoothService> services = await bluetoothDevice.discoverServices();
-    return services.where((service) {
+    return services.firstWhereOrNull((service) {
       developer.log("Service uuid: ${service.uuid.toString()}", name: TAG);
       return service.uuid.toString() ==
           BluetoothSpecification.MEASUREMENTS_SERVICE_UUID;
-    }).first;
+    });
   }
 }

--- a/lib/connection/ble/bluetooth_backend.dart
+++ b/lib/connection/ble/bluetooth_backend.dart
@@ -1,0 +1,84 @@
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_blue/flutter_blue.dart';
+import 'dart:developer' as developer;
+
+import 'bluetooth_specification.dart';
+
+/// Wrapper class to handle the communication between the app and the devices.
+class BluetoothBackend {
+  static const String TAG = "BluetoothBackend";
+
+  /// Retrieves the connected devices.
+  static Future<List<BluetoothDevice>> getConnectedDevices() {
+    return FlutterBlue.instance.connectedDevices;
+  }
+
+  /// Sends the commands specified as a parameter to the connected devices
+  /// through the measurements characteristic.
+  ///
+  /// This method is expected to be used to start and stop the measurement
+  /// readings from the glove.
+  ///
+  /// @param devicesSnapshot: snapshot of the devices currently connected via
+  ///   bluetooth.
+  static void sendCommandToConnectedDevices(
+      AsyncSnapshot<List<BluetoothDevice>> devicesSnapshot,
+      String command) async {
+    List<BluetoothCharacteristic> characteristics =
+    await BluetoothBackend.getMeasurementCharacteristics(devicesSnapshot);
+    characteristics.forEach((characteristic) async {
+      try {
+        await characteristic.write(utf8.encode(command), withoutResponse: true);
+      } catch (err) {
+        developer.log("Characteristic write failed: " + err.toString(),
+            name: TAG);
+      }
+    });
+  }
+
+  /// Retrieves the measurement characteristics of all the connected devices.
+  ///
+  /// By retrieving all the measurement characteristics of the connected devices
+  /// (expected to be one characteristic each) we can then broadcast a command
+  /// to all of them.
+  ///
+  /// @param devicesSnapshot: snapshot of the devices currently connected via
+  ///   bluetooth.
+  static Future<List<BluetoothCharacteristic>> getMeasurementCharacteristics(
+      AsyncSnapshot<List<BluetoothDevice>> devicesSnapshot) async {
+    List<BluetoothCharacteristic> characteristics = <BluetoothCharacteristic>[];
+    for (var device in devicesSnapshot.data!) {
+      BluetoothService service = await getMeasurementService(device);
+      BluetoothCharacteristic measurementCharacteristic =
+      getMeasurementCharacteristic(service);
+      characteristics.add(measurementCharacteristic);
+    }
+    developer.log("Measurement characteristics: $characteristics", name: TAG);
+    return characteristics;
+  }
+
+  /// Retrieves the measurement characteristic from the {@code bluetoothService}
+  /// specified.
+  static BluetoothCharacteristic getMeasurementCharacteristic(
+      BluetoothService bluetoothService) {
+    return bluetoothService.characteristics
+        .where((characteristic) =>
+    characteristic.uuid.toString() ==
+        BluetoothSpecification.MEASUREMENTS_CHARACTERISTIC_UUID)
+        .first;
+  }
+
+  /// Retrieves the measurement service from the specified device.
+  static Future<BluetoothService> getMeasurementService(
+      BluetoothDevice bluetoothDevice) async {
+    List<BluetoothService> services = await bluetoothDevice.discoverServices();
+    return services.where((service) {
+      developer.log("Service uuid: ${service.uuid.toString()}", name: TAG);
+      return service.uuid.toString() ==
+          BluetoothSpecification.MEASUREMENTS_SERVICE_UUID;
+    }).first;
+  }
+}

--- a/lib/connection/ble/bluetooth_backend.dart
+++ b/lib/connection/ble/bluetooth_backend.dart
@@ -1,4 +1,3 @@
-
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -21,14 +20,10 @@ class BluetoothBackend {
   ///
   /// This method is expected to be used to start and stop the measurement
   /// readings from the glove.
-  ///
-  /// @param devicesSnapshot: snapshot of the devices currently connected via
-  ///   bluetooth.
-  static void sendCommandToConnectedDevices(
-      AsyncSnapshot<List<BluetoothDevice>> devicesSnapshot,
-      String command) async {
+  static void sendCommandToConnectedDevices(String command) async {
+    List<BluetoothDevice> connectedDevices = await getConnectedDevices();
     List<BluetoothCharacteristic> characteristics =
-    await BluetoothBackend.getMeasurementCharacteristics(devicesSnapshot);
+        await BluetoothBackend.getMeasurementCharacteristics(connectedDevices);
     characteristics.forEach((characteristic) async {
       try {
         await characteristic.write(utf8.encode(command), withoutResponse: true);
@@ -44,16 +39,13 @@ class BluetoothBackend {
   /// By retrieving all the measurement characteristics of the connected devices
   /// (expected to be one characteristic each) we can then broadcast a command
   /// to all of them.
-  ///
-  /// @param devicesSnapshot: snapshot of the devices currently connected via
-  ///   bluetooth.
   static Future<List<BluetoothCharacteristic>> getMeasurementCharacteristics(
-      AsyncSnapshot<List<BluetoothDevice>> devicesSnapshot) async {
+      List<BluetoothDevice> devicesSnapshot) async {
     List<BluetoothCharacteristic> characteristics = <BluetoothCharacteristic>[];
-    for (var device in devicesSnapshot.data!) {
+    for (var device in devicesSnapshot) {
       BluetoothService service = await getMeasurementService(device);
       BluetoothCharacteristic measurementCharacteristic =
-      getMeasurementCharacteristic(service);
+          getMeasurementCharacteristic(service);
       characteristics.add(measurementCharacteristic);
     }
     developer.log("Measurement characteristics: $characteristics", name: TAG);
@@ -66,8 +58,8 @@ class BluetoothBackend {
       BluetoothService bluetoothService) {
     return bluetoothService.characteristics
         .where((characteristic) =>
-    characteristic.uuid.toString() ==
-        BluetoothSpecification.MEASUREMENTS_CHARACTERISTIC_UUID)
+            characteristic.uuid.toString() ==
+            BluetoothSpecification.MEASUREMENTS_CHARACTERISTIC_UUID)
         .first;
   }
 

--- a/lib/connection/ble/bluetooth_backend.dart
+++ b/lib/connection/ble/bluetooth_backend.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_blue/flutter_blue.dart';
 import 'dart:developer' as developer;
 

--- a/lib/datacollection/measurements_collector.dart
+++ b/lib/datacollection/measurements_collector.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+import 'package:flutter_blue/flutter_blue.dart';
+import 'package:lsa_gloves/connection/ble/bluetooth_backend.dart';
+
+import 'dart:developer' as developer;
+
+/// Class to take in charge the responsibility of receiving and processing
+/// the measurements taken from the device.
+class MeasurementsCollector {
+  static const String TAG = "MeasurementsCollector";
+
+  late StreamSubscription<List<int>>? _subscription;
+
+  void readMeasurements() async {
+    List<BluetoothDevice> devices =
+        await BluetoothBackend.getConnectedDevices();
+    List<BluetoothCharacteristic> characteristics =
+        await BluetoothBackend.getMeasurementCharacteristics(devices);
+
+    // TODO(https://git.io/JEyV4): Process data from more than one device.
+    BluetoothCharacteristic characteristic = characteristics.first;
+    await characteristic.setNotifyValue(true);
+    _subscription = characteristic.value.listen((data) {
+      // TODO(https://git.io/JEyVE): Format files with Edge Impulse's data acquisition format.
+      // TODO(https://git.io/JEywB): Parse the incoming bytes.
+      String measurement = new String.fromCharCodes(data);
+      developer.log("Incoming data: $measurement", name: TAG);
+    }, onError: (err) {
+      developer.log("Error happened: ${err.toString()}", name: TAG);
+    }, onDone: () {
+      developer.log("Reading measurements done", name: TAG);
+    });
+  }
+
+  void stopReadings() {
+    if (_subscription != null) {
+      _subscription!.cancel();
+      developer.log("Subscription canceled.", name: TAG);
+    }
+  }
+}

--- a/lib/pages/data_collection_page.dart
+++ b/lib/pages/data_collection_page.dart
@@ -1,10 +1,8 @@
-import 'dart:convert';
-import 'dart:developer' as developer;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blue/flutter_blue.dart';
-import 'package:lsa_gloves/connection/ble/bluetooth_specification.dart';
+import 'package:lsa_gloves/connection/ble/bluetooth_backend.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
 
 import '../navigation/navigation_drawer.dart';
@@ -17,7 +15,6 @@ class DataCollectionPage extends StatefulWidget {
 }
 
 class _DataCollectionPageState extends State<DataCollectionPage> {
-  static const String TAG = "DataCollectionPageState";
   static final List<String> categories = getCategoryList();
   late String selectedCategory = categories[0];
   late List<String> gestures = getGestureList(selectedCategory);
@@ -35,7 +32,7 @@ class _DataCollectionPageState extends State<DataCollectionPage> {
         padding: EdgeInsets.all(16.0),
         child: StreamBuilder<List<BluetoothDevice>>(
             stream: Stream.periodic(Duration(seconds: 2))
-                .asyncMap((_) => FlutterBlue.instance.connectedDevices),
+                .asyncMap((_) => BluetoothBackend.getConnectedDevices()),
             initialData: [],
             builder: (c, devicesSnapshot) => Column(
                   mainAxisAlignment: MainAxisAlignment.start,
@@ -131,12 +128,12 @@ class _DataCollectionPageState extends State<DataCollectionPage> {
           onPressed: () {
             if (devicesSnapshot.data!.isNotEmpty) {
               if (!_recordingStarted) {
-                _sendCommandToConnectedDevices(devicesSnapshot, "stop");
+                BluetoothBackend.sendCommandToConnectedDevices(devicesSnapshot, "stop");
                 setState(() {
                   _buttonIcon = Icons.fiber_manual_record;
                 });
               } else {
-                _sendCommandToConnectedDevices(devicesSnapshot, "start");
+                BluetoothBackend.sendCommandToConnectedDevices(devicesSnapshot, "start");
                 setState(() {
                   _buttonIcon = Icons.stop;
                 });
@@ -157,72 +154,6 @@ class _DataCollectionPageState extends State<DataCollectionPage> {
             }
           },
         ));
-  }
-
-  /// Sends the commands specified as a parameter to the connected devices
-  /// through the measurements characteristic.
-  ///
-  /// This method is expected to be used to start and stop the measurement
-  /// readings from the glove.
-  ///
-  /// @param devicesSnapshot: snapshot of the devices currently connected via
-  ///   bluetooth.
-  void _sendCommandToConnectedDevices(
-      AsyncSnapshot<List<BluetoothDevice>> devicesSnapshot,
-      String command) async {
-    List<BluetoothCharacteristic> characteristics =
-        await _getMeasurementCharacteristics(devicesSnapshot);
-    characteristics.forEach((characteristic) async {
-      try {
-        await characteristic.write(utf8.encode(command), withoutResponse: true);
-      } catch (err) {
-        developer.log("Characteristic write failed: " + err.toString(),
-            name: TAG);
-      }
-    });
-  }
-
-  /// Retrieves the measurement characteristics of all the connected devices.
-  ///
-  /// By retrieving all the measurement characteristics of the connected devices
-  /// (expected to be one characteristic each) we can then broadcast a command
-  /// to all of them.
-  ///
-  /// @param devicesSnapshot: snapshot of the devices currently connected via
-  ///   bluetooth.
-  Future<List<BluetoothCharacteristic>> _getMeasurementCharacteristics(
-      AsyncSnapshot<List<BluetoothDevice>> devicesSnapshot) async {
-    List<BluetoothCharacteristic> characteristics = <BluetoothCharacteristic>[];
-    for (var device in devicesSnapshot.data!) {
-      BluetoothService service = await _getMeasurementService(device);
-      BluetoothCharacteristic measurementCharacteristic =
-          _getMeasurementCharacteristic(service);
-      characteristics.add(measurementCharacteristic);
-    }
-    developer.log("Measurement characteristics: $characteristics", name: TAG);
-    return characteristics;
-  }
-
-  /// Retrieves the measurement characteristic from the {@code bluetoothService}
-  /// specified.
-  BluetoothCharacteristic _getMeasurementCharacteristic(
-      BluetoothService bluetoothService) {
-    return bluetoothService.characteristics
-        .where((characteristic) =>
-            characteristic.uuid.toString() ==
-            BluetoothSpecification.MEASUREMENTS_CHARACTERISTIC_UUID)
-        .first;
-  }
-
-  /// Retrieves the measurement service from the specified device.
-  Future<BluetoothService> _getMeasurementService(
-      BluetoothDevice bluetoothDevice) async {
-    List<BluetoothService> services = await bluetoothDevice.discoverServices();
-    return services.where((service) {
-      developer.log("Service uuid: ${service.uuid.toString()}", name: TAG);
-      return service.uuid.toString() ==
-          BluetoothSpecification.MEASUREMENTS_SERVICE_UUID;
-    }).first;
   }
 
   DropdownButton<String> buildDropdownButton(List<String> values,

--- a/lib/pages/data_collection_page.dart
+++ b/lib/pages/data_collection_page.dart
@@ -128,12 +128,12 @@ class _DataCollectionPageState extends State<DataCollectionPage> {
           onPressed: () {
             if (devicesSnapshot.data!.isNotEmpty) {
               if (!_recordingStarted) {
-                BluetoothBackend.sendCommandToConnectedDevices(devicesSnapshot, "stop");
+                BluetoothBackend.sendCommandToConnectedDevices("stop");
                 setState(() {
                   _buttonIcon = Icons.fiber_manual_record;
                 });
               } else {
-                BluetoothBackend.sendCommandToConnectedDevices(devicesSnapshot, "start");
+                BluetoothBackend.sendCommandToConnectedDevices("start");
                 setState(() {
                   _buttonIcon = Icons.stop;
                 });

--- a/lib/pages/data_collection_page.dart
+++ b/lib/pages/data_collection_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blue/flutter_blue.dart';
 import 'package:lsa_gloves/connection/ble/bluetooth_backend.dart';
+import 'package:lsa_gloves/datacollection/measurements_collector.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
 
 import '../navigation/navigation_drawer.dart';
@@ -19,6 +20,12 @@ class _DataCollectionPageState extends State<DataCollectionPage> {
   late String selectedCategory = categories[0];
   late List<String> gestures = getGestureList(selectedCategory);
   late String selectedGesture = gestures[0];
+  late MeasurementsCollector _measurementsCollector;
+
+  @override
+  void initState() {
+    _measurementsCollector = MeasurementsCollector();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -127,13 +134,15 @@ class _DataCollectionPageState extends State<DataCollectionPage> {
           ),
           onPressed: () {
             if (devicesSnapshot.data!.isNotEmpty) {
-              if (!_recordingStarted) {
+              if (_recordingStarted) {
                 BluetoothBackend.sendCommandToConnectedDevices("stop");
+                _measurementsCollector.stopReadings();
                 setState(() {
                   _buttonIcon = Icons.fiber_manual_record;
                 });
               } else {
                 BluetoothBackend.sendCommandToConnectedDevices("start");
+                _measurementsCollector.readMeasurements();
                 setState(() {
                   _buttonIcon = Icons.stop;
                 });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -218,7 +218,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -321,7 +321,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.5"
+    version: "2.2.7"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
Este PR contiene los siguientes cambios:
* Se desacopla a comunicación Bluetooth de la vista de la data_collection_page, para esto se ha:
  *  generado una clase BluetoothBackend con métodos estáticos con el propósito de simplificar la comunicación con los dispositivos.
  * la información sobre el estado de los devices no depende más de AsyncSnapshots ni de Streams; cada vez que se necesita comunicarse con uno de los esp32 se le solicita a FlutterBlue la información de los dispositivos en ese momento. Este esquema tal vez se pueda optimizar en el futuro.
* Se ha generado una clase MeasurementsCollector para centralizar ahí la lógica del procesamiento de los datos recibidos.
* Se ha arreglado un bug en la pantalla de data collection relativo a los estados de la data collection.

Closes #13 