### PR TITLE
Refactor Measurements collector and dc page

### DIFF
--- a/lib/datacollection/measurements_collector.dart
+++ b/lib/datacollection/measurements_collector.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_blue/flutter_blue.dart';
+import 'package:lsa_gloves/connection/ble/bluetooth_backend.dart';
 import 'package:lsa_gloves/datacollection/storage.dart';
-import 'package:lsa_gloves/widgets/Dialog.dart';
-import 'package:flutter/cupertino.dart';
 
 import 'dart:developer' as developer;
 
@@ -13,100 +11,177 @@ import 'package:lsa_gloves/model/glove_measurement.dart';
 /// Class to take in charge the responsibility of receiving and processing
 /// the measurements taken from the device.
 class MeasurementsCollector {
-  final GlobalKey<State> _keyLoader = new GlobalKey<State>();
   static const String TAG = "MeasurementsCollector";
-  String _deviceId;
-  BluetoothCharacteristic _characteristic;
-  List<GloveMeasurement> _items;
-  StreamSubscription<List<int>>? _subscription;
 
-  MeasurementsCollector(this._deviceId, this._characteristic)
-      : _items = [];
+  Map<String, DeviceMeasurementsFile> _deviceMeasurements = Map();
+  bool isRecording = false;
+  List<StreamSubscription<List<int>>?> _subscriptions = [];
 
-  void readMeasurements(BuildContext context) async {
-    await this._characteristic.setNotifyValue(true);
-    _subscription = this._characteristic.value.listen((data) {
-      String stringRead = new String.fromCharCodes(data);
-      developer.log("Incoming data: $stringRead", name: TAG);
-      readGloveMeasurementsFromBle(stringRead);
+  /// Starts collecting measurements from all the connected devices.
+  ///
+  /// A measurements file will be generated for each device with its
+  /// collected measurements.
+  void startCollection(List<BluetoothDevice> connectedDevices, String gesture) async {
+    developer.log("Starting collection for gesture '$gesture' from devices: $connectedDevices", name: TAG);
+    for (BluetoothDevice device in connectedDevices) {
+      BluetoothService? lsaService =
+          await BluetoothBackend.getLsaGlovesService(device);
+      BluetoothCharacteristic dcCharacteristic =
+          BluetoothBackend.getDataCollectionCharacteristic(lsaService!);
+      initFile(device.id.id, gesture);
+      collectMeasurements(device.id.id, dcCharacteristic);
+    }
+    isRecording = true;
+  }
+
+  void initFile(String deviceId, String gesture) async {
+    DeviceMeasurementsFile deviceMeasurementsFile
+        = await DeviceMeasurementsFile.create(deviceId, gesture);
+    _deviceMeasurements.putIfAbsent(deviceId, () => deviceMeasurementsFile);
+  }
+
+  /// Saves the collection files and stops recording measurements.
+  void saveCollection() async {
+    _cancelSubscriptions();
+    for (var measurementsFile in _deviceMeasurements.values) {
+      await measurementsFile.save();
+    }
+    _deviceMeasurements.clear();
+    isRecording = false;
+  }
+
+  /// Discards an ongoing collection, removing the generated files.
+  void discardCollection() async {
+    _cancelSubscriptions();
+    for (var measurementsFile in _deviceMeasurements.values) {
+      await measurementsFile.deleteFile();
+    }
+    _deviceMeasurements.clear();
+    isRecording = false;
+  }
+
+  void _cancelSubscriptions() {
+    for (var subscription in _subscriptions) {
+      subscription?.cancel();
+    }
+    _subscriptions = [];
+  }
+
+  void collectMeasurements(String deviceId,
+      BluetoothCharacteristic dataCollectionCharacteristic) async {
+    if (!dataCollectionCharacteristic.isNotifying) {
+      await dataCollectionCharacteristic.setNotifyValue(true);
+    }
+    StreamSubscription<List<int>> subscription =
+        dataCollectionCharacteristic.value.listen((data) {
+      String rawMeasurements = new String.fromCharCodes(data);
+      developer.log("Incoming data: $rawMeasurements", name: TAG);
+      Pair<int, List<String>>? parsedMeasurements =
+          _parseRawMeasurements(rawMeasurements);
+      if (parsedMeasurements == null) {
+        developer.log("Measurements parsing failed.", name: TAG);
+        return;
+      }
+      var eventNum = parsedMeasurements.first;
+      _recordParsedMeasurement(deviceId, eventNum, parsedMeasurements.second);
     }, onError: (err) {
       developer.log("Error: ${err.toString()}", name: TAG);
     }, onDone: () {
       developer.log("Reading measurements done", name: TAG);
     });
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text("Capturando movimientos..."),
-        duration: Duration(seconds: 2)));
+    _subscriptions.add(subscription);
   }
 
-  readGloveMeasurementsFromBle(String stringRead) {
-    if (stringRead.isEmpty) {
-      return;
+  /// Parses the raw measurements passed as a parameter.
+  ///
+  /// Returns a pair containing:
+  ///   - first: the event number.
+  ///   - second: a list of float measurements represented as strings.
+  Pair<int, List<String>>? _parseRawMeasurements(String rawMeasurements) {
+    if (rawMeasurements.isEmpty) {
+      developer.log("Raw measurements was an empty string!", name: TAG);
+      return null;
     }
-    if (this._subscription == null || this._subscription!.isPaused) {
-      developer.log("skip: subscription is cancelled", name: TAG);
-      return;
+    var lastCharacter = rawMeasurements.substring(rawMeasurements.length - 1);
+    if (lastCharacter != ";") {
+      developer.log(
+          "Last character is not the expected delimiter ';'. Verify the MTU is set properly.",
+          name: TAG);
+      return null;
     }
-    var lastCharacter = stringRead.substring(stringRead.length - 1);
-    List<String> fingerMeasurements = stringRead
-        .substring(0, stringRead.length - 1)
+
+    List<String> fingerMeasurements = rawMeasurements
+        .substring(0, rawMeasurements.length - 1)
         .split('\n')
         .where((s) => s.isNotEmpty)
         .toList();
-    if (fingerMeasurements.length < 6 || lastCharacter != ";") {
+    if (fingerMeasurements.length < 6) {
       developer.log(
-          "last character is not the expected delimiter ';'"
-          "have you change the MTU correctly ",
+          "Fewer measurements than expected: (${fingerMeasurements.length}).",
           name: TAG);
-      return;
+      return null;
     }
-    var eventNum = int.parse(fingerMeasurements.removeAt(0));
+    int eventNum = int.parse(fingerMeasurements.removeAt(0));
+    return Pair(eventNum, fingerMeasurements);
+  }
+
+  _recordParsedMeasurement(String deviceId, int eventNumber, List<String> measurements) {
     try {
-      developer.log('trying to parse');
-      var pkg = GloveMeasurement.fromFingerMeasurementsList(
-          eventNum, this._deviceId, fingerMeasurements);
-      developer.log('map to -> ${pkg.toJson().toString()}');
-      this._items.add(pkg);
+      developer.log('Attempting to parse');
+      GloveMeasurement gloveMeasurement = GloveMeasurement.fromFingerMeasurementsList(
+          eventNumber, deviceId, measurements);
+      developer.log('map to -> ${gloveMeasurement.toJson().toString()}');
+      _deviceMeasurements[deviceId]?.add(gloveMeasurement);
     } catch (e) {
-      developer.log('cant parse : $stringRead  error : ${e.toString()}');
+      developer.log('cant parse : $measurements  error : ${e.toString()}');
     }
   }
+  
+  // _stopReadings(BuildContext context, String selectedGesture) async {
+  //   if (this._subscription != null) {
+  //     this._subscription!.cancel();
+  //     this._subscription = null;
+  //     developer.log("Subscription canceled.", name: TAG);
+  //   }
+  //   if (_items.isNotEmpty) {
+  //     _saveMessagesInFile(context, selectedGesture, this._items);
+  //     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+  //         content: Text("Movimientos guardados!"),
+  //         duration: Duration(seconds: 1)));
+  //   } else {
+  //     developer.log("Empty measurment list, nothing to save", name: TAG);
+  //   }
+  //   await _characteristic.setNotifyValue(false);
+  // }
+  //
+  // _saveMessagesInFile(BuildContext context, String selectedGesture,
+  //     List<GloveMeasurement> gloveMeasurements) async {
+  //   if (gloveMeasurements.isEmpty) {
+  //     return;
+  //   }
+  //   //open pop up loading
+  //   Dialogs.showLoadingDialog(context, _keyLoader, "Guardando...");
+  //   var deviceId = gloveMeasurements.first.deviceId;
+  //   var measurementFile =
+  //       await DeviceMeasurementsFile.create(deviceId, selectedGesture);
+  //   for (int i = 0; i < gloveMeasurements.length; i++) {
+  //     developer
+  //         .log('saving in file -> ${gloveMeasurements[i].toJson().toString()}');
+  //     measurementFile.add(gloveMeasurements[i]);
+  //   }
+  //   await measurementFile.save();
+  //   this._items = [];
+  //   //close pop up loading
+  //   Navigator.of(_keyLoader.currentContext!, rootNavigator: true).pop();
+  // }
+}
 
-  stopReadings(BuildContext context, String selectedGesture) async {
-    if (this._subscription != null) {
-     this. _subscription!.cancel();
-     this._subscription = null;
-      developer.log("Subscription canceled.", name: TAG);
-    }
-    if (_items.isNotEmpty) {
-      saveMessagesInFile(context, selectedGesture, this._items);
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text("Movimientos guardados!"),
-          duration: Duration(seconds: 1)));
-    } else {
-      developer.log("Empty measurment list, nothing to save", name: TAG);
-    }
-    await _characteristic.setNotifyValue(false);
-  }
+class Pair<T, Q> {
+  final T first;
+  final Q second;
 
-  saveMessagesInFile(BuildContext context, String selectedGesture,
-      List<GloveMeasurement> gloveMeasurements) async {
-    if (gloveMeasurements.isEmpty) {
-      return;
-    }
-    //open pop up loading
-    Dialogs.showLoadingDialog(context, _keyLoader, "Guardando...");
-    var deviceId = gloveMeasurements.first.deviceId;
-    var measurementFile =
-        await DeviceMeasurementsFile.create(deviceId, selectedGesture);
-    for (int i = 0; i < gloveMeasurements.length; i++) {
-      developer
-          .log('saving in file -> ${gloveMeasurements[i].toJson().toString()}');
-      measurementFile.add(gloveMeasurements[i]);
-    }
-    await measurementFile.save();
-    this._items = [];
-    //close pop up loading
-    Navigator.of(_keyLoader.currentContext!, rootNavigator: true).pop();
-  }
+  Pair(this.first, this.second);
+
+  @override
+  String toString() => 'Pair[$first, $second]';
 }

--- a/lib/datacollection/measurements_collector.dart
+++ b/lib/datacollection/measurements_collector.dart
@@ -31,7 +31,6 @@ class MeasurementsCollector {
           BluetoothBackend.getDataCollectionCharacteristic(lsaService!);
       _initFile(device.id.id, gesture);
       _collectMeasurements(device.id.id, dcCharacteristic);
-      sleep(Duration(milliseconds: 1000));
     }
   }
 

--- a/lib/datacollection/measurements_collector.dart
+++ b/lib/datacollection/measurements_collector.dart
@@ -23,6 +23,7 @@ class MeasurementsCollector {
   /// collected measurements.
   void startCollecting(List<BluetoothDevice> connectedDevices, String gesture) async {
     developer.log("Starting collection for gesture '$gesture' from devices: $connectedDevices", name: TAG);
+    _resetState();
     for (BluetoothDevice device in connectedDevices) {
       BluetoothService? lsaService =
           await BluetoothBackend.getLsaGlovesService(device);
@@ -35,6 +36,7 @@ class MeasurementsCollector {
   }
 
   /// Saves the collection files and stops recording measurements.
+
   void saveCollection() async {
     _cancelSubscriptions();
     for (var measurementsFile in _deviceMeasurements.values) {
@@ -42,17 +44,21 @@ class MeasurementsCollector {
     }
     _deviceMeasurements.clear();
   }
-  
   /// Discards an ongoing collection, removing the generated files.
+
   void discardCollection() async {
-    _cancelSubscriptions();
-    _deviceMeasurements.clear();
+    _resetState();
   }
-  
+
   void _initFile(String deviceId, String gesture) async {
     DeviceMeasurementsFile deviceMeasurementsFile
         = await DeviceMeasurementsFile.create(deviceId, gesture);
     _deviceMeasurements.putIfAbsent(deviceId, () => deviceMeasurementsFile);
+  }
+
+  void _resetState() {
+    _cancelSubscriptions();
+    _deviceMeasurements.clear();
   }
 
   void _cancelSubscriptions() {

--- a/lib/datacollection/measurements_collector.dart
+++ b/lib/datacollection/measurements_collector.dart
@@ -15,7 +15,7 @@ class MeasurementsCollector {
   static const String TAG = "MeasurementsCollector";
 
   Map<String, DeviceMeasurementsFile> _deviceMeasurements = Map();
-  List<StreamSubscription<List<int>>?> _subscriptions = [];
+  List<StreamSubscription<List<int>>> _subscriptions = [];
 
   /// Starts collecting measurements from all the connected devices.
   ///
@@ -36,7 +36,6 @@ class MeasurementsCollector {
   }
 
   /// Saves the collection files and stops recording measurements.
-
   void saveCollection() async {
     _cancelSubscriptions();
     for (var measurementsFile in _deviceMeasurements.values) {
@@ -44,8 +43,8 @@ class MeasurementsCollector {
     }
     _deviceMeasurements.clear();
   }
-  /// Discards an ongoing collection, removing the generated files.
 
+  /// Discards an ongoing collection, removing the generated files.
   void discardCollection() async {
     _resetState();
   }
@@ -63,7 +62,7 @@ class MeasurementsCollector {
 
   void _cancelSubscriptions() {
     for (var subscription in _subscriptions) {
-      subscription?.cancel();
+      subscription.cancel();
     }
     _subscriptions = [];
   }

--- a/lib/datacollection/measurements_collector.dart
+++ b/lib/datacollection/measurements_collector.dart
@@ -136,44 +136,6 @@ class MeasurementsCollector {
       developer.log('cant parse : $measurements  error : ${e.toString()}');
     }
   }
-  
-  // _stopReadings(BuildContext context, String selectedGesture) async {
-  //   if (this._subscription != null) {
-  //     this._subscription!.cancel();
-  //     this._subscription = null;
-  //     developer.log("Subscription canceled.", name: TAG);
-  //   }
-  //   if (_items.isNotEmpty) {
-  //     _saveMessagesInFile(context, selectedGesture, this._items);
-  //     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-  //         content: Text("Movimientos guardados!"),
-  //         duration: Duration(seconds: 1)));
-  //   } else {
-  //     developer.log("Empty measurment list, nothing to save", name: TAG);
-  //   }
-  //   await _characteristic.setNotifyValue(false);
-  // }
-  //
-  // _saveMessagesInFile(BuildContext context, String selectedGesture,
-  //     List<GloveMeasurement> gloveMeasurements) async {
-  //   if (gloveMeasurements.isEmpty) {
-  //     return;
-  //   }
-  //   //open pop up loading
-  //   Dialogs.showLoadingDialog(context, _keyLoader, "Guardando...");
-  //   var deviceId = gloveMeasurements.first.deviceId;
-  //   var measurementFile =
-  //       await DeviceMeasurementsFile.create(deviceId, selectedGesture);
-  //   for (int i = 0; i < gloveMeasurements.length; i++) {
-  //     developer
-  //         .log('saving in file -> ${gloveMeasurements[i].toJson().toString()}');
-  //     measurementFile.add(gloveMeasurements[i]);
-  //   }
-  //   await measurementFile.save();
-  //   this._items = [];
-  //   //close pop up loading
-  //   Navigator.of(_keyLoader.currentContext!, rootNavigator: true).pop();
-  // }
 }
 
 class Pair<T, Q> {

--- a/lib/datacollection/storage.dart
+++ b/lib/datacollection/storage.dart
@@ -60,7 +60,6 @@ class DeviceMeasurementsFile {
   
   String get path => file.path;
   String get lastModified => "$lastModificationDate";
-  
 
   DeviceMeasurementsFile._(
       this.file,

--- a/lib/datacollection/storage.dart
+++ b/lib/datacollection/storage.dart
@@ -105,7 +105,7 @@ class DeviceMeasurementsFile {
       await file.delete();
       developer.log("file deleted");
     } catch (e) {
-      developer.log("cant delete file");
+      developer.log("Cant delete file: ${e.toString()}");
     }
   }
 
@@ -152,16 +152,17 @@ class SensorMeasurements {
       return false;
     }
     List<double> measurementList = [];
-    addFingerMovements(measurementList, gloveMeasurement.pinky);
-    addFingerMovements(measurementList, gloveMeasurement.ring);
-    addFingerMovements(measurementList, gloveMeasurement.middle);
-    addFingerMovements(measurementList, gloveMeasurement.index);
-    addFingerMovements(measurementList, gloveMeasurement.thumb);
+    measurementList.addAll(extractFingerMeasurement(gloveMeasurement.pinky));
+    measurementList.addAll(extractFingerMeasurement(gloveMeasurement.ring));
+    measurementList.addAll(extractFingerMeasurement(gloveMeasurement.middle));
+    measurementList.addAll(extractFingerMeasurement(gloveMeasurement.index));
+    measurementList.addAll(extractFingerMeasurement(gloveMeasurement.thumb));
     this.values.add(measurementList);
     return true;
   }
 
-  bool addFingerMovements(measurementList, Finger finger){
+  List<double> extractFingerMeasurement(Finger finger){
+    List<double> measurementList = [];
     measurementList.add(finger.acc.x);
     measurementList.add(finger.acc.y);
     measurementList.add(finger.acc.z);
@@ -171,8 +172,7 @@ class SensorMeasurements {
     measurementList.add(finger.inclination.roll);
     measurementList.add(finger.inclination.pitch);
     measurementList.add(finger.inclination.yaw);
-    this.values.add(measurementList);
-    return true;
+    return measurementList;
   }
 
   factory SensorMeasurements.fromJson(dynamic json) {

--- a/lib/pages/ble_data_collection_page.dart
+++ b/lib/pages/ble_data_collection_page.dart
@@ -100,7 +100,7 @@ class _BleDataCollectionState extends State<BleDataCollectionPage> {
   
   void onRecordButtonPressed() {
     if (_isRecording) {
-      stopRecording();
+      _stopRecording();
     } else {
       _startRecording();
     }
@@ -115,13 +115,13 @@ class _BleDataCollectionState extends State<BleDataCollectionPage> {
           maintainState: false));
     } else {
       BluetoothBackend.sendStartDataCollectionCommand(_connectedDevices!);
-      _measurementsCollector.startCollection(this._connectedDevices!, this.selectedGesture);
+      _measurementsCollector.startCollecting(this._connectedDevices!, this.selectedGesture);
       _isRecording = true;
       // TODO(https://git.io/JEyV4): Process data from more than one device.
     }
   }
 
-  void stopRecording() async {
+  void _stopRecording() async {
     developer.log('stopRecording');
     BluetoothBackend.sendStopCommand(this._connectedDevices!);
     _isRecording = false;
@@ -244,7 +244,6 @@ class _RecordButtonState extends State<RecordButton> with SingleTickerProviderSt
               icon: Icon(Icons.stop, color: Colors.red, size: 64),
               onPressed: () {
                 onButtonPressed.call();
-                // stopRecording();
                 _timerController.reset();
                 setState(() {
                   _isRecording = false;
@@ -257,7 +256,6 @@ class _RecordButtonState extends State<RecordButton> with SingleTickerProviderSt
                   color: Theme.of(context).primaryColor, size: 64),
               onPressed: () {
                 onButtonPressed.call();
-                // startRecording();
                 _timerController.start();
                 setState(() {
                   _isRecording = true;

--- a/lib/pages/ble_data_collection_page.dart
+++ b/lib/pages/ble_data_collection_page.dart
@@ -127,6 +127,7 @@ class _BleDataCollectionState extends State<BleDataCollectionPage> {
     _isRecording = false;
     showDialog(
         context: context,
+        barrierDismissible: false,
         builder: (_) => AlertDialog(
           title: Text("Finalizar recolección."),
           content: Text(

--- a/lib/pages/ble_data_collection_page.dart
+++ b/lib/pages/ble_data_collection_page.dart
@@ -89,8 +89,7 @@ class _BleDataCollectionState extends State<BleDataCollectionPage> {
                   SizedBox(height: 74),
                   RecordButton(
                       key: Key("${devicesSnapshot.data!.length}"),
-                      onButtonPressed: () => onRecordButtonPressed(),
-                      devicesSnapshot: devicesSnapshot)
+                      onButtonPressed: () => onRecordButtonPressed())
                 ],
               );
             }),
@@ -180,33 +179,21 @@ class _BleDataCollectionState extends State<BleDataCollectionPage> {
 
 class RecordButton extends StatefulWidget {
 
-  final AsyncSnapshot<List<BluetoothDevice>> devicesSnapshot;
   final Function onButtonPressed;
 
-  const RecordButton({Key? key, required this.devicesSnapshot, required this.onButtonPressed}) : super(key: key);
+  const RecordButton({Key? key, required this.onButtonPressed}) : super(key: key);
 
   @override
-  _RecordButtonState createState() => _RecordButtonState(devicesSnapshot, onButtonPressed);
+  _RecordButtonState createState() => _RecordButtonState(onButtonPressed);
 }
 
 class _RecordButtonState extends State<RecordButton> with SingleTickerProviderStateMixin {
-  final AsyncSnapshot<List<BluetoothDevice>> devicesSnapshot;
-  late List<BluetoothDevice> connectedDevices;
   late TimerController _timerController;
   bool _isRecording = false;
   Function onButtonPressed;
 
-  _RecordButtonState(this.devicesSnapshot, this.onButtonPressed) {
+  _RecordButtonState(this.onButtonPressed) {
     _timerController = new TimerController(this);
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    if (devicesSnapshot.hasData) {
-      connectedDevices = devicesSnapshot.data!;
-    }
-    developer.log("Widget updated. Devices: " + connectedDevices.toString(), name: "RecordButton");
   }
 
   @override


### PR DESCRIPTION
En este PR se modifica el código de forma tal de que el measurements collector:
- no tenga responsabilidades con respecto de la vista (suprimiendo la responsabilidad de disparar un snackbar)
- soporta multiples devices, generando un archivo por cada uno conectado
- su lifespan es el de la pantalla de recolección, no se ocupa de buscar los devices conectados, sino que los recibe por parámetro en el método start collection
- envía los datos recolectados de los devices directamente a instancias de `DeviceMeasurementsFile` en lugar de almacenar internamente una lista para luego generar el device measurements file

La vista del ble_data_collection_page se ha refactorizado un poco:
- El botón con el progress bar se agrupan en un widget llamado RecordButton
- A este widget se le pasa por parámetro una callback para ejecutarse cuando se presiona el botón, de este modo el código a ejecutarse en el cual se interactúa con el measurements collector se ubica adentro del _BleDataCollectionState, evitando así que el RecordButton deba tener internamente el measurements collector para interactuar con el (dándole una responsabilidad que no le corresponde).
- Al querer detenerse la data collection, aparece un dialog ofreciendo al usuario la posibilidad de descartar los archivos de la collection o de guardarlos.
- Se fixea el error de los dispositivos no conectados al presionar el botón de grabar