### PR TITLE
Connection + settings page integration with bluetooth backend model

### DIFF
--- a/lib/connection/ble/bluetooth_backend.dart
+++ b/lib/connection/ble/bluetooth_backend.dart
@@ -146,8 +146,16 @@ class BluetoothBackend with ChangeNotifier {
     }
   }
 
-  static void sendCalibrationCommand(BluetoothDevice device) async {
-    sendCommandToConnectedDevice(device, BluetoothSpecification.CALIBRATE);
+  void sendCalibrationCommand(BluetoothDevice device) async {
+    BluetoothCharacteristic? controller = _controllerCharacteristics[device];
+    if (controller != null) {
+      writeCommandToCharacteristic(
+          BluetoothSpecification.CALIBRATE, controller);
+    } else {
+      developer.log(
+          "Controller characteristic not found for device ${device.id.id}!",
+          name: TAG);
+    }
   }
 
   static Future sendStopCommandToDevices(List<BluetoothDevice> connectedDevices) async {

--- a/lib/connection/ble/bluetooth_backend.dart
+++ b/lib/connection/ble/bluetooth_backend.dart
@@ -34,18 +34,30 @@ class BluetoothBackend with ChangeNotifier {
   Map<BluetoothDevice, BluetoothCharacteristic>
       get interpretationCharacteristics => _interpretationCharacteristics;
 
+  /// Stream providing the information of the connected devices. This stream
+  /// monitors the connected devices every 2 seconds.
   late Stream<List<BluetoothDevice>> connectedDevicesStream;
 
+  late Stream<List<BluetoothDevice>> availableDevicesStream;
+
   BluetoothBackend() {
+    _initializeStreams();
     _startMonitoringDevices();
+  }
+
+  void _initializeStreams() {
+    availableDevicesStream = FlutterBlue.instance.scanResults.map((list) => list
+        .where((scanResult) => scanResult.advertisementData.connectable)
+        .map((scanResult) => scanResult.device)
+        .toList(growable: true));
+    this.connectedDevicesStream = Stream.periodic(Duration(seconds: 2))
+        .asyncMap((_) => BluetoothBackend.getConnectedDevices())
+        .asBroadcastStream();
   }
 
   /// Starts monitoring the connected devices and notifies the listeners of this
   /// class when a connection event (i.e. connection or disconnection) happens.
   void _startMonitoringDevices() {
-    this.connectedDevicesStream = Stream.periodic(Duration(seconds: 2))
-        .asyncMap((_) => BluetoothBackend.getConnectedDevices())
-        .asBroadcastStream();
     this.connectedDevicesStream.listen((newConnectedDevices) async {
       if (this._connectedDevices.length != newConnectedDevices.length) {
         developer.log("Connection event.", name: TAG);

--- a/lib/connection/ble/bluetooth_device.dart
+++ b/lib/connection/ble/bluetooth_device.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_blue/flutter_blue.dart';
 import 'package:lsa_gloves/connection/ble/bluetooth_backend.dart';
 import 'package:lsa_gloves/connection/ble/bluetooth_specification.dart';
-import 'dart:developer' as developer;
+
+import 'package:provider/provider.dart';
 
 class DeviceScreen extends StatefulWidget {
   const DeviceScreen({Key? key, required this.device, required this.isEnabled})
@@ -82,7 +83,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         onPressed: (_isEnabled &&
                                 snapshot.data == BluetoothDeviceState.connected)
                             ? () {
-                                BluetoothBackend.sendCalibrationCommand(device);
+                                Provider.of<BluetoothBackend>(context)
+                                    .sendCalibrationCommand(device);
                                 ScaffoldMessenger.of(context)
                                     .showSnackBar(SnackBar(
                                         content: Row(


### PR DESCRIPTION
Integrando la lógica de las pantallas de Dispositivos y de las settings de los dispositivos con el Bluetooth backend.

En la pantalla de dispositivos disponibles, se ha modificado la lógica interna de forma tal que los dispositivos que estén conectados se muestren instantáneamente (yendo a buscar esa info al estado del backend), arreglando el fenómeno que sucedía cuando cargabas la página e inicialmente no se mostraba ningún dispositivo (por más que estuvieran conectados uno o dos) hasta que después del escaneo automático los encontraba nuevamente. Ahora, ya que tenemos la información de que tenemos unos dispositivos conectados, la mostramos de entrada. No obstante, para encontrar dispositivos que no estén conectados (y no hayan sido desconectados in situ en la pantalla, en cuyo caso sí se muestran) se debe realizar un escaneo.

La pantalla de configuración del dispositivo sigue igual, nomás que ya no se busca la característica de control para enviar la orden sino que obtenemos esa información del estado del backend, optimizando eso.